### PR TITLE
fixed bytes encoding for python 3

### DIFF
--- a/zappa/asynchronous.py
+++ b/zappa/asynchronous.py
@@ -178,7 +178,7 @@ class LambdaAsyncResponse:
         Given a message, directly invoke the lamdba function for this task.
         """
         message['command'] = 'zappa.asynchronous.route_lambda_task'
-        payload = json.dumps(message).encode('utf-8')
+        payload = json.dumps(message)
         if len(payload) > LAMBDA_ASYNC_PAYLOAD_LIMIT: # pragma: no cover
             raise AsyncException("Payload too large for async Lambda call")
         self.response = self.client.invoke(


### PR DESCRIPTION
## Description
When running async functions utilizing SNS as service, botocore complains that payload is bytes and not string. Linked issues in main repo alluded to this fix, though are still open at the time of this PR.

## GitHub Issues
https://github.com/Miserlou/Zappa/issues/1323
https://github.com/Miserlou/Zappa/issues/1592

